### PR TITLE
build multiarch images on amd64 machine

### DIFF
--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -14,7 +14,13 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-328
+FROM alpine as builder
+
+RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-ppc64le-static
+
+RUN chmod +x /qemu-ppc64le-static
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f8174ab3c2fb4bd8aae29c48e077ba8e67c91904a639dd950b4c7e21c857cfec
 ARG VCS_REF
 ARG VCS_URL
 
@@ -35,8 +41,10 @@ ENV OPERATOR=/usr/local/bin/meta-operator \
   USER_UID=1001 \
   USER_NAME=meta-operator
 
+COPY --from=builder /qemu-ppc64le-static /usr/bin/
+
 # install operator binary
-COPY build/_output/bin/meta-operator ${OPERATOR}
+COPY build/_output/bin/meta-operator-ppc64le ${OPERATOR}
 COPY deploy/crds ${DEPLOY_DIR}
 
 COPY build/bin /usr/local/bin

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -14,7 +14,13 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-328
+FROM alpine as builder
+
+RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-s390x-static
+
+RUN chmod +x /qemu-s390x-static
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c4be843e7dbeeea865e7f93787f00d5e20c425a895ab56998c93bb6dc88abfe4
 ARG VCS_REF
 ARG VCS_URL
 
@@ -35,8 +41,10 @@ ENV OPERATOR=/usr/local/bin/meta-operator \
   USER_UID=1001 \
   USER_NAME=meta-operator
 
+COPY --from=builder /qemu-s390x-static /usr/bin/
+
 # install operator binary
-COPY build/_output/bin/meta-operator ${OPERATOR}
+COPY build/_output/bin/meta-operator-s390x ${OPERATOR}
 COPY deploy/crds ${DEPLOY_DIR}
 
 COPY build/bin /usr/local/bin


### PR DESCRIPTION
fixes https://github.com/IBM/meta-operator/issues/39

The newly added targets will be skipped when running on non-amd64 machine.

/cc @morvencao @gyliu513 @DanielXLee @horis233 