### PR TITLE
Add init status for config and catalog

### DIFF
--- a/pkg/apis/operator/v1alpha1/metaoperatorcatalog_types.go
+++ b/pkg/apis/operator/v1alpha1/metaoperatorcatalog_types.go
@@ -89,6 +89,7 @@ type OperatorPhase string
 
 // Operator status
 const (
+	OperatorReady   OperatorPhase = "Ready for Deployment"
 	OperatorRunning OperatorPhase = "Running"
 	OperatorFailed  OperatorPhase = "Failed"
 )

--- a/pkg/apis/operator/v1alpha1/metaoperatorconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/metaoperatorconfig_types.go
@@ -90,6 +90,7 @@ type ServicePhase string
 
 // Service status
 const (
+	ServiceReady   ServicePhase = "Ready for Deployment"
 	ServiceRunning ServicePhase = "Running"
 	ServiceFailed  ServicePhase = "Failed"
 )

--- a/pkg/controller/metaoperatorset/catalog_status.go
+++ b/pkg/controller/metaoperatorset/catalog_status.go
@@ -22,6 +22,28 @@ import (
 	operatorv1alpha1 "github.com/IBM/meta-operator/pkg/apis/operator/v1alpha1"
 )
 
+func (r *ReconcileMetaOperatorSet) initOperatorStatus(cr *operatorv1alpha1.MetaOperatorCatalog) error {
+
+	if cr.Status.OperatorsStatus == nil {
+		cr.Status.OperatorsStatus = make(map[string]operatorv1alpha1.OperatorPhase)
+	}
+	change := false
+	for _, operator := range cr.Spec.Operators {
+		if _, ok := cr.Status.OperatorsStatus[operator.Name]; !ok {
+			cr.Status.OperatorsStatus[operator.Name] = operatorv1alpha1.OperatorReady
+			change = true
+		}
+	}
+
+	if change {
+		if err := r.client.Status().Update(context.TODO(), cr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *ReconcileMetaOperatorSet) updateOperatorStatus(cr *operatorv1alpha1.MetaOperatorCatalog, operatorName string, operatorStatus operatorv1alpha1.OperatorPhase) error {
 
 	if cr.Status.OperatorsStatus == nil {


### PR DESCRIPTION
#47 #45 
operator-sdk scorecard tests the `status` field of the CR when they are created.