### PR TITLE
Add controller for csv and sub

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -101,7 +101,7 @@ linters-settings:
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 200
+    line-length: 300
     # tab width in spaces. Default to 1.
     tab-width: 1
   unused:

--- a/deploy/crds/operator.ibm.com_v1alpha1_metaoperatorcatalog_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_metaoperatorcatalog_cr.yaml
@@ -5,35 +5,35 @@ metadata:
 spec:
   operators:
   - name: ibm-metering-operator
-    namespace: ibm-metering-operator
+    namespace: meta-operator
     channel: alpha
     packageName: ibm-metering-operator-app
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
     description: The service used to meter workloads in a kubernetes cluster
   - name: ibm-licensing-operator
-    namespace: ibm-licensing-operator
+    namespace: meta-operator
     channel: alpha
     packageName: ibm-licensing-operator-app
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
     description: The service used to management the license in a kubernetes cluster
   - name: ibm-mongodb-operator
-    namespace: ibm-mongodb-operator
+    namespace: meta-operator
     channel: alpha
     packageName: ibm-mongodb-operator-app
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
     description: The service used to create mongodb in a kubernetes cluster
   - name: ibm-cert-manager-operator
-    namespace: ibm-cert-manager-operator
+    namespace: meta-operator
     channel: alpha
     packageName: ibm-cert-manager-operator
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
     description: Operator for managing deployment of cert-manager service.
   - name: ibm-healthcheck-operator
-    namespace: ibm-healthcheck-operator
+    namespace: meta-operator
     channel: alpha
     packageName: ibm-healthcheck-operator-app
     sourceName: opencloud-operators

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-openapi/spec v0.19.4
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5
 	github.com/operator-framework/operator-sdk v0.15.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,6 @@ github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62F
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jsonnet-bundler/jsonnet-bundler v0.1.0/go.mod h1:YKsSFc9VFhhLITkJS3X2PrRqWG9u2Jq99udTdDjQLfM=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
-github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
-github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=

--- a/pkg/controller/metaoperatorset/metaoperatorset_controller.go
+++ b/pkg/controller/metaoperatorset/metaoperatorset_controller.go
@@ -236,7 +236,7 @@ func (r *ReconcileMetaOperatorSet) Reconcile(request reconcile.Request) (reconci
 	}
 
 	// Reconcile the MetaOperatorConfig
-	merr := r.reconcileMetaOperatorConfig(serviceConfigs, csc)
+	merr := r.reconcileMetaOperatorConfig(setInstance, serviceConfigs, csc)
 
 	if len(merr.errors) != 0 {
 		return reconcile.Result{}, merr

--- a/pkg/controller/metaoperatorset/reconcile_metaoperatorconfig.go
+++ b/pkg/controller/metaoperatorset/reconcile_metaoperatorconfig.go
@@ -153,7 +153,7 @@ func (r *ReconcileMetaOperatorSet) generateCr(service operatorv1alpha1.ConfigSer
 
 	// Create a slice for crTemplates
 	var crTemplates []interface{}
-	fmt.Println(almExamples)
+
 	// Convert CR template string to slice
 	crTemplatesErr := json.Unmarshal([]byte(almExamples), &crTemplates)
 	if crTemplatesErr != nil {


### PR DESCRIPTION
fix #89 

In this PR I convert all the common service to `meta-operator` namespace and add metaoperatorset instance as the controller of the common service operator's CSV and sub. 
