### PR TITLE
Update namespace to ibm-common-services

### DIFF
--- a/docs/dev/e2e.md
+++ b/docs/dev/e2e.md
@@ -11,16 +11,16 @@
 
 1. Ensure **operator-sdk** is installed and login to your OpenShift cluster as an admin user.
 
-1. If the namespace **meta-operator** exists, delete it. Do this to make sure the namespace is clean.
+1. If the namespace **ibm-common-services** exists, delete it. Do this to make sure the namespace is clean.
 
     ```bash
-    oc delete namespace meta-operator
+    oc delete namespace ibm-common-services
     ```
 
-1. Create the namespace **meta-operator**.
+1. Create the namespace **ibm-common-services**.
 
     ```bash
-    oc create namespace meta-operator
+    oc create namespace ibm-common-services
     ```
 
 1. Run the test using `make test-e2e`  command locally.

--- a/docs/install/common-service-integration.md
+++ b/docs/install/common-service-integration.md
@@ -27,7 +27,7 @@
   - [3.Make a pull request to merge the changes](#3make-a-pull-request-to-merge-the-changes)
 - [End to end test](#end-to-end-test)
   - [1. Create an OperatorSource in the Openshift cluster](#1-create-an-operatorsource-in-the-openshift-cluster)
-  - [2. Create a Namespace `meta-operator`](#2-create-a-namespace-meta-operator)
+  - [2. Create a Namespace `ibm-common-services`](#2-create-a-namespace-ibm-common-services)
   - [3. Install meta Operator](#3-install-meta-operator)
   - [4. Check the installed operators](#4-check-the-installed-operators)
   - [5. Edit the MetaOperator Config custom resource and the MetaOperator Catalog custom resource](#5-edit-the-metaoperator-config-custom-resource-and-the-metaoperator-catalog-custom-resource)
@@ -369,9 +369,9 @@ spec:
   type: appregistry
 ```
 
-## 2. Create a Namespace `meta-operator`
+## 2. Create a Namespace `ibm-common-services`
 
-Open `OperatorHub` page in OCP console left menu, then `Create Project`, e.g., create a project named `meta-operator`.
+Open `OperatorHub` page in OCP console left menu, then `Create Project`, e.g., create a project named `ibm-common-services`.
 
 ## 3. Install meta Operator
 
@@ -390,7 +390,7 @@ Open `Installed Operators` page to check the installed operators.
 
 ```bash
 vi deploy/crds/operator.ibm.com_v1alpha1_metaoperatorset_cr.yaml
-oc apply -f deploy/crds/operator.ibm.com_v1alpha1_metaoperatorset_cr.yaml -n meta-operator
+oc apply -f deploy/crds/operator.ibm.com_v1alpha1_metaoperatorset_cr.yaml -n ibm-common-services
 ```
 
 - [Editing MetaOperator Set](#edit-a-metaoperator-set-custom-resource)

--- a/docs/install/install-with-kind.md
+++ b/docs/install/install-with-kind.md
@@ -3,15 +3,12 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Install the meta operator on vanila Kubernetes](#install-the-meta-operator-on-vanila-kubernetes)
-    - [Deploy meta operator](#deploy-meta-operator)
-        - [1. Deploy a Kubernetes cluster](#1-deploy-a-kubernetes-cluster)
-        - [2. Install OLM](#2-install-olm)
-        - [3. Create CatalogSource](#3-create-catalogsource)
-        - [4. Create Operator Namespace, OperatorGroup, Subscription](#4-create-operator-namespace-operatorgroup-subscription)
-        - [5. Check Operator CSV](#5-check-operator-csv)
-    - [How to use mate operator to install services](#how-to-use-mate-operator-to-install-services)
-        - [1. Update MetaOperatorConfig and MetaOperatorCatalog custom resource](#1-update-metaoperatorconfig-and-metaoperatorcatalog-custom-resource)
-        - [2. Create MetaOperatorSet custom resource](#2-create-metaoperatorset-custom-resource)
+  - [Deploy meta operator](#deploy-meta-operator)
+    - [1. Deploy a Kubernetes cluster](#1-deploy-a-kubernetes-cluster)
+    - [2. Install OLM](#2-install-olm)
+    - [3. Create CatalogSource](#3-create-catalogsource)
+    - [4. Create Operator Namespace, OperatorGroup, Subscription](#4-create-operator-namespace-operatorgroup-subscription)
+    - [5. Check Operator CSV](#5-check-operator-csv)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -65,24 +62,24 @@ kubectl apply -f - <<END
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: meta-operator
+  name: ibm-common-services
 
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: operatorgroup
-  namespace: meta-operator
+  namespace: ibm-common-services
 spec:
   targetNamespaces:
-  - meta-operator
+  - ibm-common-services
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: meta-operator
-  namespace: meta-operator
+  namespace: ibm-common-services
 spec:
   channel: alpha
   name: meta-operator-app

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -3,21 +3,18 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Install the meta operator](#install-the-meta-operator)
-    - [Install the meta operator On OCP 4.x](#install-the-meta-operator-on-ocp-4x)
-        - [1. Create OperatorSource](#1-create-operatorsource)
-        - [2. Create a Namespace `meta-operator`](#2-create-a-namespace-meta-operator)
-        - [3. Install meta Operator](#3-install-meta-operator)
-        - [4. Check the installed operators](#4-check-the-installed-operators)
-    - [Install the meta operator On OCP 3.11](#install-the-meta-operator-on-ocp-311)
-        - [0. Install OLM](#0-install-olm)
-        - [1. Build Operator Registry image](#1-build-operator-registry-image)
-        - [2. Create CatalogSource](#2-create-catalogsource)
-        - [3. Create Operator NS, Group, Subscription](#3-create-operator-ns-group-subscription)
-        - [4. Check Operator CSV](#4-check-operator-csv)
-    - [Create and update custom resource](#create-and-update-custom-resource)
-        - [1. Update MetaOperatorConfig and MetaOperatorCatalog custom resource](#1-update-metaoperatorconfig-and-metaoperatorcatalog-custom-resource)
-        - [2. Create MetaOperatorSet custom resource](#2-create-metaoperatorset-custom-resource)
-    - [Post-installation](#post-installation)
+  - [Install the meta operator On OCP 4.x](#install-the-meta-operator-on-ocp-4x)
+    - [1. Create OperatorSource](#1-create-operatorsource)
+    - [2. Create a Namespace `ibm-common-services`](#2-create-a-namespace-ibm-common-services)
+    - [3. Install meta Operator](#3-install-meta-operator)
+    - [4. Check the installed operators](#4-check-the-installed-operators)
+  - [Install the meta operator On OCP 3.11](#install-the-meta-operator-on-ocp-311)
+    - [0. Install OLM](#0-install-olm)
+    - [1. Build Operator Registry image](#1-build-operator-registry-image)
+    - [2. Create CatalogSource](#2-create-catalogsource)
+    - [3. Create Operator NS, Group, Subscription](#3-create-operator-ns-group-subscription)
+    - [4. Check Operator CSV](#4-check-operator-csv)
+  - [Post-installation](#post-installation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -44,9 +41,9 @@ spec:
   type: appregistry
 ```
 
-### 2. Create a Namespace `meta-operator`
+### 2. Create a Namespace `ibm-common-services`
 
-Open the `OperatorHub` page in OCP console left menu, then `Create Project`, e.g., create a project named `meta-operator`.
+Open the `OperatorHub` page in OCP console left menu, then `Create Project`, e.g., create a project named `ibm-common-services`.
 
 ### 3. Install meta Operator
 
@@ -93,24 +90,24 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: meta-operator
+  name: ibm-common-services
 
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: operatorgroup
-  namespace: meta-operator
+  namespace: ibm-common-services
 spec:
   targetNamespaces:
-  - meta-operator
+  - ibm-common-services
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: meta-operator
-  namespace: meta-operator
+  namespace: ibm-common-services
 spec:
   channel: alpha
   name: meta-operator-app


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is used to update the namespace in the document to the `ibm-common-services`.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
    ```
    None
    ```
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
